### PR TITLE
fix: Add capability to pass session to the connector

### DIFF
--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -60,7 +60,6 @@ class WalletConnectProvider implements IEthereumProvider {
         break;
     }
     if (SIGNING_METHODS.includes(args.method)) {
-      this.events.emit("message", {type: 'request'});
       return this.signer.request(args);
     }
     if (typeof this.http === "undefined") {

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -60,6 +60,7 @@ class WalletConnectProvider implements IEthereumProvider {
         break;
     }
     if (SIGNING_METHODS.includes(args.method)) {
+      this.events.emit("message", {type: 'request'});
       return this.signer.request(args);
     }
     if (typeof this.http === "undefined") {

--- a/packages/provider/src/signer.ts
+++ b/packages/provider/src/signer.ts
@@ -114,6 +114,7 @@ export class SignerConnection extends IJsonRpcConnection {
       storageId: opts?.storageId,
       signingMethods: opts?.signingMethods,
       clientMeta: opts?.clientMeta,
+      session: opts?.session,
     };
     this.wc =
       typeof opts?.connector !== "undefined" ? opts.connector : new WalletConnect(connectorOpts);

--- a/packages/types/src/jsonrpc.ts
+++ b/packages/types/src/jsonrpc.ts
@@ -1,4 +1,4 @@
-import { IClientMeta, IConnector } from "./protocol";
+import { IClientMeta, IConnector, IWalletConnectSession } from "./protocol";
 import { IEvents } from "./events";
 import { IQRCodeModal, IQRCodeModalOptions } from "./qrcode";
 
@@ -84,6 +84,7 @@ export interface IWCRpcConnectionOptions {
   signingMethods?: string[];
   qrcodeModalOptions?: IQRCodeModalOptions;
   clientMeta?: IClientMeta;
+  session: IWalletConnectSession;
 }
 
 export interface IWCEthRpcConnectionOptions extends IWCRpcConnectionOptions {


### PR DESCRIPTION
In non-web environments `_getStorageSession` doesn't work. It relies on local storage + the ISessionStorage interface is synchronous which prevents me from passing my own from envs like React Native. 

An alternative to keep the WC session is to let users store the session on their own and let them pass it down to the connector at creation time. This is what this PR tries to accomplish.

I tested this in a React Native environment by patch-packaging the files and got it to work as expected. 